### PR TITLE
Update homepage text content and fix Stripe API compatibility

### DIFF
--- a/app/api/stripe/create-checkout-session/route.ts
+++ b/app/api/stripe/create-checkout-session/route.ts
@@ -3,7 +3,7 @@ import Stripe from 'stripe';
 
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2023-10-16',
+      apiVersion: '2025-08-27.basil',
     })
   : null;
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -4,7 +4,7 @@ import { sendBookingNotificationEmail } from '@/lib/email';
 
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2023-10-16',
+      apiVersion: '2025-08-27.basil',
     })
   : null;
 

--- a/lib/text.tsx
+++ b/lib/text.tsx
@@ -463,7 +463,7 @@ export const HomePageText = {
   features: "Food, views, photos, and a take-home treat",
   luggage: "Luggage storage guidance included",
   bookNow: "Book Your Seattle Tour",
-  lovedBy: "Loved by travelers from 20+ countries",
+  lovedBy: "Loved by travelers from 10+ attractions",
   thinking: "You're probably thinking…",
   thinking1Title: "“Six hours? Is that even enough?”",
   thinking1Description: "Absolutely. We've designed this as a condensed, <strong>no stress</strong> experience that <strong>skips lines</strong>, avoids hassles, and guides you through Seattle's highlights — food, views, and photos — all with <strong>time to spare</strong>.",
@@ -487,12 +487,12 @@ export const HomePageText = {
   phoneNumber: "(206) 928‑1277",
   whatsapp: "WhatsApp",
   whatsappNumber: "(206) 928‑1277",
-  countries: "20+",
-  countriesLabel: "Countries",
-  perfectTime: "6hrs",
-  perfectTimeLabel: "Perfect Time",
+  countries: "10+",
+  countriesLabel: "Attractions",
+  perfectTime: "6+ Hrs",
+  perfectTimeLabel: "Perfect time",
   ctaTitle: "Seattle's best bites, views, and a guaranteed on-time return.",
-  ctaSubtitle: "Loved by travelers from 20+ countries",
+  ctaSubtitle: "Loved by travelers from 10+ attractions",
 };
 
 export const PricingPageText = {


### PR DESCRIPTION
- Change "20+ countries" to "10+ attractions" across homepage
- Update "6hrs Perfect Time" to "6+ Hrs Perfect time"
- Fix Stripe API version compatibility (2023-10-16 -> 2025-08-27.basil)

🤖 Generated with [Claude Code](https://claude.ai/code)